### PR TITLE
Implement connected-components with Kosaraju's algorithm

### DIFF
--- a/srfi-234-test.scm
+++ b/srfi-234-test.scm
@@ -71,6 +71,19 @@
                                (5 2) (5 6)
                                (6 5)
                                (7 4) (7 6) (7 7))))
+
+(test-equal
+    '((0 1 2) (3 4) (5 6) (7))
+  (connected-components
+   (edgelist->graph '((0 1)
+                      (1 2)
+                      (2 0)
+                      (3 1) (3 2) (3 4)
+                      (4 3) (4 5)
+                      (5 2) (5 6)
+                      (6 5)
+                      (7 4) (7 6) (7 7)))))
+
 (define (permutations edgelist)
   (if (null? edgelist) '(())
       (apply append

--- a/srfi-234-test.scm
+++ b/srfi-234-test.scm
@@ -73,7 +73,7 @@
                                (7 4) (7 6) (7 7))))
 
 (test-equal
-    '((0 1 2) (3 4) (5 6) (7))
+    '((2 0 1) (6 5) (3 4) (7))
   (connected-components
    (edgelist->graph '((0 1)
                       (1 2)

--- a/srfi/234-impl.scm
+++ b/srfi/234-impl.scm
@@ -79,6 +79,9 @@
       (raise (make-circular-graph "graph has circular dependency" (map car rest)))))
   (reverse result))
 
+;; Calculate the connected components from a graph
+(define (connected-components graph) #f)
+
 ;; convert an edgelist '((a b) (a c) (b e)) to a graph '((a b c) (b e))
 (define edgelist->graph
   (case-lambda

--- a/srfi/234.sld
+++ b/srfi/234.sld
@@ -10,5 +10,6 @@
             edgelist->graph
             edgelist/inverted->graph
             graph->edgelist
-            graph->edgelist/inverted)
+            graph->edgelist/inverted
+            connected-components)
     (include "234-impl.scm"))

--- a/srfi/234.sld
+++ b/srfi/234.sld
@@ -2,7 +2,8 @@
     (import
         (scheme base)
         (scheme case-lambda)
-        (srfi 1))
+        (srfi 1)
+        (srfi 26)) ;; cut
     (export topological-sort
             circular-graph?
             circular-graph-message


### PR DESCRIPTION
This moves one step closer to get done.

Remaining TODO:

- [ ] change to returning `(values #f error-message)` when the graph contains cycles.
- [ ] document the procedure connected-components
- [ ] define what the default for ~=~ is — use =equal?=
- [ ] Specify in the spec =circular-graph?=, =circular-graph-message=, =circular-graph-cycle= https://srfi-email.schemers.org/srfi-234/msg/21391924/
- [ ] Note that this does topological sorting with simple edgelists.
- [ ] define accessors for the graph like `graph-incoming graph node` and `graph-nodes` so implementations can use other underlying datastructures.