### PR TITLE
Resolve the last unresolved questions

### DIFF
--- a/srfi-234-test.scm
+++ b/srfi-234-test.scm
@@ -118,7 +118,7 @@
              (equal? (circular-graph-cycle err) '(b a))))
          (cont #t))
      (lambda ()
-       (topological-sort '((a b)
+       (topological-sort/exception '((a b)
                            (b a)))
        (test-assert #f)))))
 

--- a/srfi-234.html
+++ b/srfi-234.html
@@ -67,11 +67,17 @@ meaning that <em>dependents</em> are dependent on <em>node</em>.
 The optional argument <em>=</em> specifies the identity relation
 between nodes; it defaults to <code>eqv?</code>.</p>
 
+<p>Returns the list of topologically sorted nodes or <code>#f</code>
+if the graph cannot be sorted topologically.</p>
+
+<p>If <em>graph</em> is circular, <code>topological-sort</code> may
+return <code>values</code> where the second value is an error message
+and the third value provides information about at least one cycle. If
+a second and third value are provided outside error conditions, they
+must both be <code>#f</code>.</p>
+
 <p>It is an error if the same node (in the sense of <em>=</em>) appears
 at the head  of more than one connection.<p>
-
-<p>If <em>graph</em> is circular, an error satisfying
-<code>circular-graph?</code> is signaled.</p>
 
 <p>The graph shown above can be represented as
 <code>((5 11) (7 11 8) (3 8 10) (11 2 9 10) (8 9))</code>.
@@ -79,6 +85,14 @@ One possible result of applying `topological-sort` to this graph
 is the list <code>(3 7 5 11 2 8 10 9)</code>, meaning that
 performing steps 3, 7, 5, ..., 10, 9 in that order will satisfy
 the partial ordering of the graph.</p>
+
+<p><code>(topological-sort/exception </code><em>graph</em><code>)</code><br>
+<code>(topological-sort/exception </code><em>graph =</em><code>)</code></p>
+
+<p>Returns the sorted nodes from <code>topologica-sort</code> when
+there are no cycles, but if <em>graph</em> is circular, an error
+satisfying
+<code>circular-graph?</code> is signaled.</p>
 
 <p><code>(edgelist-&gt;graph </code><em>edgelist</em><code>)</code><br>
 <code>(edgelist-&gt;graph </code><em>edgelist =</em><code>)</code></p>

--- a/srfi-234.html
+++ b/srfi-234.html
@@ -33,9 +33,12 @@ Babenhauserheide took over authorship in 2023.</p>
 Topological sorting is an algorithm that takes a graph consisting of
 nodes and other nodes that depend on them, forming a partial order,
 and returns a list representing a total ordering of the graph. If the
-graph is cyclic, the topological sort will fail, and an error will be
-signaled. This SRFI includes utilities to operate on simple
-edgelists.
+graph is cyclic, the topological sort will fail. With the
+procedure <code>topological-sort</code>, failure results in
+returning <code>#false</code> and additional information is provided
+via multiple values. With <code>topological-sort/exception</code>, an
+error will be signalled on failure. This SRFI includes utilities to
+operate on simple edgelists.
 </p>
 
 <h2 id="issues">Issues</h2>

--- a/srfi-234.html
+++ b/srfi-234.html
@@ -65,7 +65,7 @@ which is a list of connections.  Each connection is a list of the form
 <code>(</code><em>node dependent dependent</em> ...<code>)</code>,
 meaning that <em>dependents</em> are dependent on <em>node</em>.
 The optional argument <em>=</em> specifies the identity relation
-between nodes; it defaults to <code>eqv?</code>.</p>
+between nodes; it defaults to <code>equal?</code>.</p>
 
 <p>Returns the list of topologically sorted nodes or <code>#f</code>
 if the graph cannot be sorted topologically.</p>
@@ -97,12 +97,18 @@ satisfying
 <p><code>(edgelist-&gt;graph </code><em>edgelist</em><code>)</code><br>
 <code>(edgelist-&gt;graph </code><em>edgelist =</em><code>)</code></p>
 
-<p>Convert an edgelist <code>'((a b) (a c) (b e))</code> to a graph <code>'((a b c) (b e))</code></p>
+<p>Convert an edgelist <code>'((a b) (a c) (b e))</code> to a
+graph <code>'((a b c) (b e))</code>. The optional argument <em>=</em>
+specifies the identity relation between nodes; it defaults
+to <code>equal?</code>.</p>
 
 <p><code>(edgelist/inverted-&gt;graph </code><em>edgelist</em><code>)</code><br>
 <code>(edgelist/inverted-&gt;graph </code><em>edgelist =</em><code>)</code></p>
 
-<p>Convert an edgelist <code>'((b a) (c a) (e b))</code> to the inverted graph <code>'((a b c) (b e))</code></p>
+<p>Convert an edgelist <code>'((b a) (c a) (e b))</code> to the
+inverted graph <code>'((a b c) (b e))</code>. The optional
+argument <em>=</em> specifies the identity relation between nodes; it
+defaults to <code>equal?</code>.</p>
 
 <p><code>(graph-&gt;edgelist </code><em>graph</em><code>)</code></p>
 

--- a/srfi-234.html
+++ b/srfi-234.html
@@ -94,6 +94,22 @@ there are no cycles, but if <em>graph</em> is circular, an error
 satisfying
 <code>circular-graph?</code> is signaled.</p>
 
+<p><code>(circular-graph? </code><em>exception</em><code>)</code></p>
+
+<p>Returns <code>#t</code> if the exception raised
+by <code>topological-sort/exception</code> signals a circular graph.</p>
+
+<p><code>(circular-graph-message </code><em>exception</em><code>)</code></p>
+
+<p>Returns the message of an exception
+matching <code>circular-graph?</code>.</p>
+
+<p><code>(circular-graph-cycle </code><em>exception</em><code>)</code></p>
+
+<p>Returns one circular structure from an exception
+matching <code>circular-graph?</code>. The <em>graph</em> may contain
+additional cycles.</p>
+
 <p><code>(edgelist-&gt;graph </code><em>edgelist</em><code>)</code><br>
 <code>(edgelist-&gt;graph </code><em>edgelist =</em><code>)</code></p>
 

--- a/srfi-234.html
+++ b/srfi-234.html
@@ -32,9 +32,10 @@ Babenhauserheide took over authorship in 2023.</p>
 <p>
 Topological sorting is an algorithm that takes a graph consisting of
 nodes and other nodes that depend on them, forming a partial order,
-and returns a list representing a total ordering of the graph.
-If the graph is cyclic, the topological sort will fail, and an
-error will be signaled.
+and returns a list representing a total ordering of the graph. If the
+graph is cyclic, the topological sort will fail, and an error will be
+signaled. This SRFI includes utilities to operate on simple
+edgelists.
 </p>
 
 <h2 id="issues">Issues</h2>

--- a/srfi/234-impl.scm
+++ b/srfi/234-impl.scm
@@ -16,6 +16,11 @@
   (cycle circular-graph-cycle))
 
 ;;  nodes : a list of (<from> <to0> <to1> ...)
+(define (topological-sort/exception . args)
+  (let-values (((result message cycle) (apply topological-sort args)))
+    (or result
+        (raise (make-circular-graph message cycle)))))
+
 (define topological-sort
   (case-lambda
     ((nodes) (topological-sort-impl nodes eqv?))
@@ -75,9 +80,9 @@
   (let ((rest (filter (lambda (e)
                         (not (zero? (cdr e))))
                       table)))
-    (unless (null? rest)
-      (raise (make-circular-graph "graph has circular dependency" (map car rest)))))
-  (reverse result))
+    (if (null? rest)
+        (values (reverse result) #f #f)
+        (values #f "graph has circular dependency" (map car rest)))))
 
 ;; Calculate the connected components from a graph of in-neighbors
 ;; implements Kosaraju's algorithm: https://en.wikipedia.org/wiki/Kosaraju%27s_algorithm

--- a/srfi/234-impl.scm
+++ b/srfi/234-impl.scm
@@ -23,7 +23,7 @@
 
 (define topological-sort
   (case-lambda
-    ((nodes) (topological-sort-impl nodes eqv?))
+    ((nodes) (topological-sort-impl nodes equal?))
     ((nodes eq) (topological-sort-impl nodes eq))))
 
 (define (topological-sort-impl nodes eq)
@@ -129,7 +129,7 @@
 ;; convert an edgelist '((a b) (a c) (b e)) to a graph '((a b c) (b e))
 (define edgelist->graph
   (case-lambda
-    ((edgelist) (edgelist->graph-impl edgelist eqv?))
+    ((edgelist) (edgelist->graph-impl edgelist equal?))
     ((edgelist eq) (edgelist->graph-impl edgelist eq))))
 (define (edgelist->graph-impl edgelist eq)
   (let loop ((graph '()) (edges edgelist))
@@ -152,7 +152,7 @@
 ;; convert an inverted edgelist '((b a) (c a) (e b)) to a graph '((a b c) (b e))
 (define edgelist/inverted->graph
   (case-lambda
-    ((edgelist) (edgelist/inverted->graph-impl edgelist eqv?))
+    ((edgelist) (edgelist/inverted->graph-impl edgelist equal?))
     ((edgelist eq) (edgelist/inverted->graph-impl edgelist eq))))
 (define (edgelist/inverted->graph-impl edgelist eq)
   (let loop ((graph '()) (edges edgelist))

--- a/srfi/234.sld
+++ b/srfi/234.sld
@@ -3,8 +3,10 @@
         (scheme base)
         (scheme case-lambda)
         (srfi 1)
+        (srfi 11) ;; let-values
         (srfi 26)) ;; cut
     (export topological-sort
+            topological-sort/exception
             circular-graph?
             circular-graph-message
             circular-graph-cycle


### PR DESCRIPTION
- Change to returning `#f` for cycles (allowing `(values #f message circular)`) and providing `topological-sort/exception` for the previous behavior
- Use` `equal?` as default for `=` — and document for the edgelist procs
- Document the exception
- Note the possibility to use edgelists in the abstract